### PR TITLE
整体重构了tcp、tcpserver、udp、udpserver的结构，将地址结构脱离给堆管理，降低了单个套接字的大小，可以选择将地址结构…

### DIFF
--- a/Star_Tool/Star_Tool.vcxproj.filters
+++ b/Star_Tool/Star_Tool.vcxproj.filters
@@ -67,10 +67,9 @@
     <ClInclude Include="tool\value_translate.h" />
     <ClInclude Include="thread_tool\interrupt_cin.h" />
     <ClInclude Include="algorithm\async_quick_sort.h" />
-    <ClInclude Include="thread_tool\cpp\thread_pool.cpp" />
     <ClInclude Include="tool\shared_ptr.h" />
-    <ClInclude Include="net_tool\net_shared.h" />
     <ClInclude Include="tool\get_set.h" />
+    <ClInclude Include="net_tool\net_shared.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="cs.cpp">
@@ -83,5 +82,6 @@
     <ClCompile Include="thread_tool\cpp\interrupt_cin.cpp" />
     <ClCompile Include="net_tool\cpp\net_shared.cpp" />
     <ClCompile Include="net_tool\cpp\tcp_socket.cpp" />
+    <ClCompile Include="thread_tool\cpp\thread_pool.cpp" />
   </ItemGroup>
 </Project>

--- a/Star_Tool/net_tool/cpp/net_shared.cpp
+++ b/Star_Tool/net_tool/cpp/net_shared.cpp
@@ -1,5 +1,13 @@
 #include"../net_shared.h"
-
+#ifdef _WIN32
+#define STAR_INVALID_SOCKET INVALID_SOCKET
+#define STAR_IN4ADDR_ANY in4addr_any
+#define STAR_IN6ADDR_ANY in6addr_any
+#elif __linux__
+#define STAR_INVALID_SOCKET -1
+#define STAR_IN4ADDR_ANY htonl(INADDR_ANY)
+#define STAR_IN6ADDR_ANY IN6ADDR_ANY_INIT
+#endif // WIN32
 namespace star {
 	net_exception::net_exception(std::string error_msg)
 		:std::exception(), error_msg("net_exception_error:"+error_msg)
@@ -9,7 +17,6 @@ namespace star {
 	{
 		return error_msg.c_str();
 	}
-	
 }
 
 #ifdef _WIN32
@@ -55,3 +62,134 @@ namespace star {
 #elif  __linux__
 
 #endif // WIN32
+
+namespace star {
+	socket_addr_container::socket_addr_container(unsigned short port, ip_type ip_protocol)
+		:ip_protocol(ip_protocol)
+	{
+#ifdef _WIN32
+		std::call_once(star::net_Initialize_flag, star::net_Initialize);
+		if (!isInitialize.load()) {
+			throw net_exception("windows net initialize fail!\n");
+		}
+#endif // _WIN32
+		memset(this, 0, sizeof(socket_addr_container));
+		switch (ip_protocol)
+		{
+		case star::ip_type::ipv4:
+			this->addr_len = sizeof(sockaddr_in);
+			this->ip_protocol = star::ip_type::ipv4;
+#ifdef _WIN32
+			this->ip_address.ipv4.sin_addr = STAR_IN4ADDR_ANY;
+#elif __linux__
+			this->ip_address.ipv4.sin_addr.s_addr = STAR_IN4ADDR_ANY;
+#endif // _WIN32
+			this->ip_address.ipv4.sin_family = AF_INET;
+			this->ip_address.ipv4.sin_port = htons(port);
+			break;
+		case star::ip_type::ipv6:
+			this->addr_len = sizeof(sockaddr_in6);
+			this->ip_protocol = star::ip_type::ipv4;
+			this->ip_address.ipv6.sin6_addr = STAR_IN6ADDR_ANY;
+			this->ip_address.ipv6.sin6_family = AF_INET6;
+			this->ip_address.ipv6.sin6_port = htons(port);
+			break;
+		default:
+			throw net_exception("undefined ip type!\n");
+			break;
+		}
+	}
+
+	socket_addr_container::socket_addr_container()
+	{
+		memset(this, 0, sizeof(socket_addr_container));
+	}
+
+	socket_addr_container::socket_addr_container(std::string domain)
+	{
+#ifdef _WIN32
+		std::call_once(star::net_Initialize_flag, star::net_Initialize);
+		if (!isInitialize.load()) {
+			throw net_exception("windows net initialize fail!\n");
+		}
+#endif // _WIN32
+		int ret;
+		memset(this, 0, sizeof(socket_addr_container));
+		addrinfo* result;
+		ret = getaddrinfo(domain.c_str(), nullptr, nullptr, &result);
+		if (ret == 0)
+		{
+			switch (result->ai_family)
+			{
+			case AF_INET:
+				this->addr_len = result->ai_addrlen;
+				this->ip_protocol = star::ip_type::ipv4;
+				this->ip_address.ipv4 = *((struct sockaddr_in*)result->ai_addr);
+				break;
+			case AF_INET6:
+				this->addr_len = result->ai_addrlen;
+				this->ip_protocol = star::ip_type::ipv4;
+				this->ip_address.ipv6 = *((struct sockaddr_in6*)result->ai_addr);
+				break;
+			default:
+				freeaddrinfo(result);
+				throw net_exception("IP or DNS analysis failed!");
+				break;
+			}
+			freeaddrinfo(result);
+		}
+		else
+		{
+			throw net_exception("IP or DNS analysis failed!");
+		}
+	}
+
+	socket_addr_container::socket_addr_container(std::string ip, unsigned short port)
+	{
+#ifdef _WIN32
+		std::call_once(star::net_Initialize_flag, star::net_Initialize);
+		if (!isInitialize.load()) {
+			throw net_exception("windows net initialize fail!\n");
+		}
+#endif // _WIN32
+		int ret;
+		memset(this, 0, sizeof(socket_addr_container));
+		addrinfo* result;
+		ret = getaddrinfo(ip.c_str(), nullptr, nullptr, &result);
+		if (ret == 0)
+		{
+			switch (result->ai_family)
+			{
+			case AF_INET:
+				this->addr_len = result->ai_addrlen;
+				this->ip_protocol = star::ip_type::ipv4;
+				this->ip_address.ipv4 = *((struct sockaddr_in*)result->ai_addr);
+				this->ip_address.ipv4.sin_family = AF_INET;
+				this->ip_address.ipv4.sin_port = htons(port);
+				break;
+			case AF_INET6:
+				this->addr_len = result->ai_addrlen;
+				this->ip_protocol = star::ip_type::ipv4;
+				this->ip_address.ipv6 = *((struct sockaddr_in6*)result->ai_addr);
+				this->ip_address.ipv6.sin6_family = AF_INET6;
+				this->ip_address.ipv6.sin6_port = htons(port);
+				break;
+			default:
+				freeaddrinfo(result);
+				throw net_exception("IP or DNS analysis failed!");
+				break;
+			}
+			freeaddrinfo(result);
+		}
+		else
+		{
+			throw net_exception("IP or DNS analysis failed!");
+		}
+	}
+
+	socket_addr_container::socket_addr_container(socket_addr_container&& MoveSource) noexcept
+		:ip_address(MoveSource.ip_address), addr_len(MoveSource.addr_len), ip_protocol(MoveSource.ip_protocol)
+	{
+		memset(&MoveSource, 0, sizeof(MoveSource));
+	}
+}

--- a/Star_Tool/net_tool/cpp/tcp_socket.cpp
+++ b/Star_Tool/net_tool/cpp/tcp_socket.cpp
@@ -16,64 +16,71 @@ namespace star {
 	extern void net_Initialize();
 #endif
 	tcp_socket::tcp_socket()
-		:star_socket_handle(STAR_INVALID_SOCKET), IP_type(star::ip_type::ipv4), close_flag(false), block_flag(true)
-	{
-		memset(&ip_address, 0, sizeof(socket_addr));
-	}
+		:star_socket_handle(STAR_INVALID_SOCKET), close_flag(false), block_flag(true), ip_address(std::make_shared<socket_addr_container>())
+	{}
 
 	tcp_socket::tcp_socket(tcp_socket&& MoveSource) noexcept
 		: close_flag(MoveSource.close_flag.load()), star_socket_handle(std::move(MoveSource.star_socket_handle)),
-		ip_address(std::move(MoveSource.ip_address)), address_len(MoveSource.address_len),
-		IP_type(MoveSource.IP_type), block_flag(MoveSource.block_flag.load())
+		ip_address(std::move(MoveSource.ip_address)), block_flag(MoveSource.block_flag.load())
 	{
 		MoveSource.star_socket_handle = STAR_INVALID_SOCKET;
 		MoveSource.close_flag.store(true, std::memory_order_release);
 	}
 
-	tcp_socket::tcp_socket(std::string ip, unsigned short port, star::ip_type IP_type)
-		:close_flag(false), IP_type(IP_type), block_flag(true)
+	tcp_socket::tcp_socket(std::string ip_or_domain, unsigned short port)
+		:close_flag(false), block_flag(true)
 	{
 #ifdef _WIN32
 		std::call_once(star::net_Initialize_flag, star::net_Initialize);
 		if (!isInitialize.load()) {
-			throw net_exception("windows net initialize fail!\n");
+			throw net_exception("windows net initialize fail!");
 		}
 #endif // _WIN32
+		this->ip_address = std::make_shared<socket_addr_container>(ip_or_domain, port);
 		int ret;
-		memset(&ip_address, 0, sizeof(socket_addr));
-		switch (IP_type)
+		switch (this->ip_address->ip_protocol)
 		{
 		case star::ip_type::ipv4:
-			ret = inet_pton(AF_INET, ip.c_str(), &(ip_address.ipv4.sin_addr));
-			if (ret != 1) {
-				throw net_exception("ip translation failed!\n");
-			}
-			ip_address.ipv4.sin_family = AF_INET;
-			ip_address.ipv4.sin_port = htons(port);
 			this->star_socket_handle = socket(AF_INET, SOCK_STREAM, 0);
-			this->address_len = sizeof(sockaddr_in);
-			ret = connect(this->star_socket_handle, (star_sockaddr*)&(this->ip_address.ipv4), address_len);
-			if (ret != 0) {
-				this->close();
-			}
 			break;
 		case star::ip_type::ipv6:
-			ret = inet_pton(AF_INET6, ip.c_str(), &(ip_address.ipv6.sin6_addr));
-			if (ret != 1) {
-				throw net_exception("ip translation failed!\n");
-			}
-			ip_address.ipv6.sin6_family = AF_INET6;
-			ip_address.ipv6.sin6_port = htons(port);
 			this->star_socket_handle = socket(AF_INET6, SOCK_STREAM, 0);
-			this->address_len = sizeof(sockaddr_in6);
-			ret = connect(this->star_socket_handle, (star_sockaddr*)&(this->ip_address.ipv6), address_len);
-			if (ret != 0) {
-				this->close();
-			}
 			break;
 		default:
-			throw net_exception("undefined ip type!\n");
+			throw net_exception("undefined ip type!");
 			break;
+		}
+		ret = connect(this->star_socket_handle, (star_sockaddr*)&(this->ip_address->ip_address), this->ip_address->addr_len);
+		if (ret != 0) {
+			this->close();
+		}
+	}
+
+	tcp_socket::tcp_socket(std::string domain_name)
+	{
+#ifdef _WIN32
+		std::call_once(star::net_Initialize_flag, star::net_Initialize);
+		if (!isInitialize.load()) {
+			throw net_exception("windows net initialize fail!");
+		}
+#endif // _WIN32
+		this->ip_address = std::make_shared<socket_addr_container>(domain_name);
+		int ret;
+		switch (this->ip_address->ip_protocol)
+		{
+		case star::ip_type::ipv4:
+			this->star_socket_handle = socket(AF_INET, SOCK_STREAM, 0);
+			break;
+		case star::ip_type::ipv6:
+			this->star_socket_handle = socket(AF_INET6, SOCK_STREAM, 0);
+			break;
+		default:
+			throw net_exception("undefined ip type!");
+			break;
+		}
+		ret = connect(this->star_socket_handle, (star_sockaddr*)&(this->ip_address->ip_address), this->ip_address->addr_len);
+		if (ret != 0) {
+			this->close();
 		}
 	}
 
@@ -180,88 +187,76 @@ namespace star {
 		return this->close_flag.load(std::memory_order_acquire);
 	}
 
-	void tcp_socket_server::Initialize(unsigned short port)
+	void tcp_socket::freeAddr()
 	{
-		switch (this->IP_type)
-		{
-		case star::ip_type::ipv4:
-			ip_address.ipv4.sin_family = AF_INET;
-			ip_address.ipv4.sin_port = htons(port);
-			this->star_socket_handle = socket(AF_INET, SOCK_STREAM, 0);
-			this->address_len = sizeof(sockaddr_in);
-			bind(this->star_socket_handle, (tcp_socket::star_sockaddr*)&(this->ip_address.ipv4), address_len);
-			break;
-		case star::ip_type::ipv6:
-			ip_address.ipv6.sin6_family = AF_INET6;
-			ip_address.ipv6.sin6_port = htons(port);
-			this->star_socket_handle = socket(AF_INET6, SOCK_STREAM, 0);
-			this->address_len = sizeof(sockaddr_in6);
-			bind(this->star_socket_handle, (tcp_socket::star_sockaddr*)&(this->ip_address.ipv6), address_len);
-			break;
-		default:
-			throw net_exception("undefined ip type!\n");
-			break;
-		}
-		listen(this->star_socket_handle, this->connect_num);
+		this->ip_address = nullptr;
 	}
 
-	tcp_socket_server::tcp_socket_server(std::string ip, unsigned short port, int connect_num, star::ip_type IP_type)
-		:close_flag(false), IP_type(IP_type), connect_num(connect_num)
+	std::shared_ptr<socket_addr_container> tcp_socket::getAddr()
+	{
+		return this->ip_address;
+	}
+
+	tcp_socket_server::tcp_socket_server(std::string ip_or_domain, unsigned short port, int connect_num)
+		:close_flag(false), connect_num(connect_num)
 	{
 #ifdef _WIN32
 		std::call_once(star::net_Initialize_flag, star::net_Initialize);
 		if (!isInitialize.load()) {
-			throw net_exception("windows net initialize fail!\n");
+			throw net_exception("windows net initialize fail!");
 		}
 #endif // _WIN32
+		this->ip_address = std::make_shared<socket_addr_container>(ip_or_domain, port);
 		int ret;
-		switch (IP_type)
+		switch (this->ip_address->ip_protocol)
 		{
 		case star::ip_type::ipv4:
-			ret = inet_pton(AF_INET, ip.c_str(), &(ip_address.ipv4.sin_addr));
-			if (ret != 1) {
-				throw net_exception("ip translation failed!\n");
-			}
+			this->star_socket_handle = socket(AF_INET, SOCK_STREAM, 0);
 			break;
 		case star::ip_type::ipv6:
-			ret = inet_pton(AF_INET6, ip.c_str(), &(ip_address.ipv6.sin6_addr));
-			if (ret != 1) {
-				throw net_exception("ip translation failed!\n");
-			}
+			this->star_socket_handle = socket(AF_INET6, SOCK_STREAM, 0);
 			break;
 		default:
-			throw net_exception("undefined ip type!\n");
+			throw net_exception("undefined ip type!");
 			break;
 		}
-		this->Initialize(port);
+		ret = bind(this->star_socket_handle, (tcp_socket::star_sockaddr*)&(this->ip_address->ip_address), this->ip_address->addr_len);
+		if (ret != 0)
+			throw net_exception("socket bind address fail!");
+		ret = listen(this->star_socket_handle, this->connect_num);
+		if (ret != 0)
+			throw net_exception("socket set listen state fail!");
 	}
 
-	tcp_socket_server::tcp_socket_server(unsigned short port, int connect_num, star::ip_type IP_type)
-		:close_flag(false), IP_type(IP_type), connect_num(connect_num)
+	tcp_socket_server::tcp_socket_server(unsigned short port, star::ip_type IP_type, int connect_num)
+		:close_flag(false), connect_num(connect_num)
 	{
 #ifdef _WIN32
 		std::call_once(star::net_Initialize_flag, star::net_Initialize);
 		if (!isInitialize.load()) {
-			throw net_exception("windows net initialize fail!\n");
+			throw net_exception("windows net initialize fail!");
 		}
 #endif // _WIN32
-		switch (IP_type)
+		this->ip_address = std::make_shared<socket_addr_container>(port, IP_type);
+		int ret;
+		switch (this->ip_address->ip_protocol)
 		{
 		case star::ip_type::ipv4:
-#ifdef _WIN32
-			ip_address.ipv4.sin_addr = STAR_IN4ADDR_ANY;
-#elif __linux__
-			ip_address.ipv4.sin_addr.s_addr = STAR_IN4ADDR_ANY;
-#endif // _WIN32
+			this->star_socket_handle = socket(AF_INET, SOCK_STREAM, 0);
 			break;
 		case star::ip_type::ipv6:
-			ip_address.ipv6.sin6_addr = STAR_IN6ADDR_ANY;
+			this->star_socket_handle = socket(AF_INET6, SOCK_STREAM, 0);
 			break;
 		default:
-			throw net_exception("undefined ip type!\n");
+			throw net_exception("undefined ip type!");
 			break;
 		}
-		this->Initialize(port);
+		ret = bind(this->star_socket_handle, (tcp_socket::star_sockaddr*)&(this->ip_address->ip_address), this->ip_address->addr_len);
+		if (ret != 0)
+			throw net_exception("socket bind address fail!");
+		ret = listen(this->star_socket_handle, this->connect_num);
+		if (ret != 0)
+			throw net_exception("socket set listen state fail!");
 	}
 
 	tcp_socket_server::~tcp_socket_server()
@@ -271,37 +266,36 @@ namespace star {
 
 	tcp_socket tcp_socket_server::accept()
 	{
-		tcp_socket client_socket;
-		switch (IP_type)
+		tcp_socket client_socket{};
+		switch (this->ip_address->ip_protocol)
 		{
 		case star::ip_type::ipv4:
-			client_socket.star_socket_handle = ::accept(this->star_socket_handle,
-				(tcp_socket::star_sockaddr*)&(client_socket.ip_address.ipv4),
-				&(client_socket.address_len));
-			client_socket.IP_type = star::ip_type::ipv4;
+			client_socket.ip_address->addr_len = sizeof(sockaddr_in);
 			break;
 		case star::ip_type::ipv6:
-			client_socket.star_socket_handle = ::accept(this->star_socket_handle,
-				(tcp_socket::star_sockaddr*)&(client_socket.ip_address.ipv6),
-				&(client_socket.address_len));
-			client_socket.IP_type = star::ip_type::ipv6;
+			client_socket.ip_address->addr_len = sizeof(sockaddr_in6);
 			break;
 		default:
-			throw net_exception("undefined ip type!\n");
 			break;
 		}
+		client_socket.star_socket_handle = ::accept(this->star_socket_handle,
+			(tcp_socket::star_sockaddr*)&(client_socket.ip_address->ip_address),
+			&(client_socket.ip_address->addr_len));
 		return client_socket;
 	}
 
 	unsigned short tcp_socket_server::getPort()
 	{
-		switch (this->IP_type)
+		if (this->ip_address == nullptr) {
+			throw net_exception("socket address has been freed!");
+		}
+		switch (this->ip_address->ip_protocol)
 		{
 		case star::ip_type::ipv4:
-			return ntohs(this->ip_address.ipv4.sin_port);
+			return ntohs(this->ip_address->ip_address.ipv4.sin_port);
 			break;
 		case star::ip_type::ipv6:
-			return ntohs(this->ip_address.ipv6.sin6_port);
+			return ntohs(this->ip_address->ip_address.ipv6.sin6_port);
 			break;
 		default:
 			return 0;
@@ -325,5 +319,13 @@ namespace star {
 	bool tcp_socket_server::isClose()
 	{
 		return this->close_flag.load(std::memory_order_acquire);
+	}
+	void tcp_socket_server::freeAddr()
+	{
+		this->ip_address = nullptr;
+	}
+	std::shared_ptr<socket_addr_container> tcp_socket_server::getAddr()
+	{
+		return this->ip_address;
 	}
 }

--- a/Star_Tool/net_tool/net_shared.h
+++ b/Star_Tool/net_tool/net_shared.h
@@ -11,6 +11,7 @@
 #include<fcntl.h>
 #include<arpa/inet.h>
 #include<unistd.h>
+#include<netdb.h>
 #endif
 #include<memory>
 #include<atomic>
@@ -19,14 +20,23 @@
 #include<string.h>
 #include<iostream>
 namespace star {
-	enum class ip_type :char {	//ip族协议类型
+	/*
+	* ip协议族枚举类型：ipv4，ipv6
+	*/
+	enum class ip_type :char {
 		ipv4,
 		ipv6
 	};
+	/*
+	* 传输层协议流枚举类型：tcp，udp
+	*/
 	enum class tran_type :char {	//传输层协议流类型
 		udp,
 		tcp
 	};
+	/*
+	* 网络抛出错误类型
+	*/
 	class net_exception :public std::exception {
 	private:
 		std::string error_msg;
@@ -34,8 +44,29 @@ namespace star {
 		net_exception(std::string error_msg);
 		virtual const char* what() const throw() override;
 	};
-	union socket_addr {
-		sockaddr_in ipv4;
-		sockaddr_in6 ipv6;
+	class socket_addr_container {
+	private:
+		/*
+		* 地址联合体
+		*/
+		union socket_addr {
+			sockaddr_in ipv4;
+			sockaddr_in6 ipv6;
+		};
+	private:
+		socket_addr ip_address;
+		socklen_t addr_len;
+		ip_type ip_protocol;
+	public:
+		socket_addr_container();
+		socket_addr_container(unsigned short port, ip_type ip_protocol);
+		socket_addr_container(std::string domain);
+		socket_addr_container(std::string ip_or_domain, unsigned short port);
+		socket_addr_container(socket_addr_container&& MoveSource)noexcept;
+		socket_addr_container(const socket_addr_container&) = default;
+		friend class tcp_socket_server;
+		friend class tcp_socket;
+		friend class udp_socket_server;
+		friend class udp_socket;
 	};
 }

--- a/Star_Tool/net_tool/tcp_socket.h
+++ b/Star_Tool/net_tool/tcp_socket.h
@@ -15,16 +15,15 @@ namespace star {
 	private:
 		std::atomic<bool> close_flag;		//关闭flag
 		std::atomic<bool> block_flag;		//阻塞标志位
+		std::shared_ptr<socket_addr_container> ip_address;	//填装地址的容器
 		star_socket star_socket_handle;		//socket句柄
-		socket_addr ip_address;				//socket地址信息
-		socklen_t address_len = sizeof(star_sockaddr);	//socket地址信息长度
-		star::ip_type IP_type;				//socket种类
 		friend class tcp_socket_server;		//友元类
 		tcp_socket();						//保留默认构造函数给友元类tcp_socket_server使用
 	public:
 		tcp_socket(tcp_socket&& MoveSource) noexcept;	//移动构造函数
 		tcp_socket(const tcp_socket&) = delete;			//删除默认拷贝函数
-		tcp_socket(std::string ip, unsigned short port, star::ip_type IP_type = star::ip_type::ipv4);
+		tcp_socket(std::string ip_or_domain, unsigned short port);
+		tcp_socket(std::string domain_name);
 		~tcp_socket();
 		int read(char* buffer, int len, int offset = 0);
 		int write(char* buffer, int len, int offset = 0);
@@ -33,28 +32,38 @@ namespace star {
 		int availavle();
 		void close();
 		bool isClose();
+		/*
+		* 释放地址容器
+		*/
+		void freeAddr();
+		/*
+		* 获取地址容器
+		*/
+		std::shared_ptr<socket_addr_container> getAddr();
 	};
 
 	class tcp_socket_server {
 	private:
-		std::atomic<bool> close_flag;
-		tcp_socket::star_socket star_socket_handle;
-		socket_addr ip_address;
-		socklen_t address_len = sizeof(tcp_socket::star_sockaddr);
-		star::ip_type IP_type;
 		int connect_num;
-		void Initialize(unsigned short port);
+		tcp_socket::star_socket star_socket_handle;
+		std::shared_ptr<socket_addr_container> ip_address;	//填装地址的容器
+		std::atomic<bool> close_flag;
 	public:
-		tcp_socket_server(std::string ip, unsigned short port,
-			int connect_num = SOMAXCONN,
-			star::ip_type IP_type = star::ip_type::ipv4);
-		tcp_socket_server(unsigned short port, int connect_num = SOMAXCONN,
-			star::ip_type IP_type = star::ip_type::ipv4);
+		tcp_socket_server(std::string ip_or_domain, unsigned short port,int connect_num = SOMAXCONN);
+		tcp_socket_server(unsigned short port,star::ip_type IP_type = star::ip_type::ipv4, int connect_num = SOMAXCONN);
 		~tcp_socket_server();
 		tcp_socket accept();
 		unsigned short getPort();
 		void close();
 		bool isClose();
+		/*
+		* 释放地址容器
+		*/
+		void freeAddr();
+		/*
+		* 获取地址容器
+		*/
+		std::shared_ptr<socket_addr_container> getAddr();
 	};
 }
 

--- a/Star_Tool/net_tool/udp_socket.h
+++ b/Star_Tool/net_tool/udp_socket.h
@@ -2,18 +2,7 @@
 #include"net_shared.h"
 namespace star {
 
-	class socket_addr_container {
-	private:
-		socket_addr ip_address;
-		socklen_t addr_len;
-	public:
-		socket_addr_container();
-		socket_addr_container(std::string ip, unsigned short port, star::ip_type IP_type = star::ip_type::ipv4);
-		socket_addr_container(socket_addr_container&& MoveSource)noexcept;
-		socket_addr_container(const socket_addr_container&) = default;
-		friend class udp_socket_server;
-		friend class udp_socket;
-	};
+	
 	class udp_socket_server;
 	class udp_socket {
 	private:
@@ -27,10 +16,8 @@ namespace star {
 	private:
 		std::atomic<bool> connect_flag;							//连接状态flag
 		std::atomic<bool> close_flag;							//关闭flag
-		star_socket star_socket_handle;								//socket句柄
-		std::unique_ptr<socket_addr> ip_address;				//socket地址信息
-		socklen_t address_len = sizeof(star_sockaddr);			//socket地址信息长度
-		star::ip_type IP_type;									//socket种类
+		star_socket star_socket_handle;							//socket句柄
+		std::shared_ptr<socket_addr_container> ip_address;		//连接状态暂时存储的socket地址信息
 		friend class udp_socket_server;							//友元类
 	public:
 		udp_socket() = delete;									//删除默认构造函数
@@ -38,7 +25,7 @@ namespace star {
 		udp_socket(udp_socket&& MoveSource) noexcept;			//移动构造函数
 		~udp_socket();
 		udp_socket(const udp_socket&) = delete;					//删除默认拷贝函数
-		udp_socket(std::string ip, unsigned short port, star::ip_type IP_type = star::ip_type::ipv4);	//创建有连接状态udp套接字
+		udp_socket(std::string ip_or_domain, unsigned short port);		//创建有连接状态udp套接字
 		int readfrom(socket_addr_container& address_buffer, char* buffer, int len, int offset = 0);
 		int writefor(socket_addr_container& destination, char* buffer, int len, int offset = 0);
 		int read(char* buffer, int len, int offset = 0);
@@ -46,22 +33,24 @@ namespace star {
 		void close();
 		bool isClose();
 		bool isConnected();
+		/*
+		* 释放地址容器
+		*/
+		void freeAddr();
+		/*
+		* 获取地址容器
+		*/
+		std::shared_ptr<socket_addr_container> getAddr();
 	};
 
 	class udp_socket_server {
 	private:
 		std::atomic<bool> close_flag;
 		udp_socket::star_socket star_socket_handle;
-		socket_addr ip_address;
-		socklen_t address_len = sizeof(udp_socket::star_sockaddr);
-		star::ip_type IP_type;
-		void Initialize(unsigned short port);
+		std::shared_ptr<socket_addr_container> ip_address;	//填装接收报文的本地地址的容器
 	public:
-		udp_socket_server(std::string ip, unsigned short port,
-			int connect_num = SOMAXCONN,
-			star::ip_type IP_type = star::ip_type::ipv4);
-		udp_socket_server(short port, int connect_num = SOMAXCONN,
-			star::ip_type IP_type = star::ip_type::ipv4);
+		udp_socket_server(std::string ip_or_domain, unsigned short port);
+		udp_socket_server(short port, star::ip_type IP_type = star::ip_type::ipv4);
 		~udp_socket_server();
 		unsigned short getPort();
 		/*
@@ -74,5 +63,13 @@ namespace star {
 		int write(socket_addr_container& destination, char* buffer, int len, int offset = 0);
 		void close();
 		bool isClose();
+		/*
+		* 释放地址容器
+		*/
+		void freeAddr();
+		/*
+		* 获取地址容器
+		*/
+		std::shared_ptr<socket_addr_container> getAddr();
 	};
 }


### PR DESCRIPTION
…与套接字绑定后脱离处理，并添加了socket_addr_container地址容器单独存储用于兼容,减小udp、tcp使用上的差异性。同时支持域名解析服务，支持直接用域名创建套接字功能。